### PR TITLE
adds #purge to remove all todos

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Usage
 
 * `tod clear` permanently deletes todos marked as done from the register
 
+* `tod purge` permanently deletes pending as well as done todos from the register
+
 * `tod local` creates a '.todfile' in your current directory (instead of using a global one). Useful when you don't want to use a shared .todfile in a parent dir.
 
 The todo register is kept in the file named `.todfile` once you create at least one todo. This way you can add the file to a git or svn repository and distribute it between machines.

--- a/bin/tod
+++ b/bin/tod
@@ -70,6 +70,10 @@ def clear_done
   end
 end
 
+def purge
+  File.open(@todfile_path, "w") {} if @todfile_exists
+end
+
 def replace_todfile_with(lines)
   File.open(@todfile_path, 'w') do |todfile|
     lines.each { |line| todfile.puts line }
@@ -99,6 +103,8 @@ when 'done'
   done @query
 when 'clear'
   clear_done
+when 'purge'
+  purge
 when 'local'
   touch_todfile('.')
 end


### PR DESCRIPTION
Hello

I played with tod a little and I kind of missed the feature that "makes the fresh start" by deleting all todos(pending and done)

So I did some hacking and implemented #purge

`tod purge` simply removes all the content from the current todfile thus the register gets cleared completely

And it's also useful for debugging :)

Cheers
